### PR TITLE
Remove async-trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ futures-util = { version = "0.3", default-features = false, features = [
   "sink",
   "std",
 ] }
-async-trait = "0.1"
 anyhow = "1.0"
 thiserror = "2.0.12"
 simple-xml-builder = "1.1"

--- a/src/bt/fallback.rs
+++ b/src/bt/fallback.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use futures::future::select_all;
 use futures::{Future, FutureExt};
 
@@ -262,9 +261,8 @@ impl FallbackProcess {
     }
 }
 
-#[async_trait]
 impl Node for FallbackProcess {
-    async fn serve(mut self) {
+    async fn serve(self) {
         let poison_tx = self.tx.clone();
         let name = self.name.clone();
         let res = Self::_serve(self).await;

--- a/src/bt/handle.rs
+++ b/src/bt/handle.rs
@@ -1,6 +1,5 @@
 use actify::CacheRecvNewestError;
 use anyhow::Result;
-use async_trait::async_trait;
 use simple_xml_builder::XMLElement;
 
 use thiserror::Error;
@@ -163,9 +162,8 @@ pub enum FutResponse {
     Child(usize, ParentMessage, Receiver<ParentMessage>),
 }
 
-#[async_trait]
 pub trait Node: Sync + Send {
-    async fn serve(mut self);
+    async fn serve(self);
 
     // Consuming and returning the receiver allows stacking it in a future vector
     async fn run_listen_parent(mut rx: Receiver<ChildMessage>) -> Result<FutResponse, NodeError> {

--- a/src/bt/loop_dec.rs
+++ b/src/bt/loop_dec.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use tokio::sync::broadcast::{channel, Receiver, Sender};
 use tokio::time::{sleep, Duration};
 
@@ -162,9 +161,8 @@ impl LoopDecorator {
     }
 }
 
-#[async_trait]
 impl Node for LoopDecorator {
-    async fn serve(mut self) {
+    async fn serve(self) {
         let poison_tx = self.tx.clone();
         let name = self.name.clone();
         let res = Self::_serve(self).await;

--- a/src/bt/sequence.rs
+++ b/src/bt/sequence.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use futures::future::select_all;
 use futures::{Future, FutureExt};
 
@@ -239,9 +238,8 @@ impl SequenceProcess {
     }
 }
 
-#[async_trait]
 impl Node for SequenceProcess {
-    async fn serve(mut self) {
+    async fn serve(self) {
         let poison_tx = self.tx.clone();
         let name = self.name.clone();
         let res = Self::_serve(self).await;


### PR DESCRIPTION
This should improve compilation performance depending on how complex the end-user's implementations are of Executor. For example, for our app, it improved the compilation time (w/ cargo clean) from 2m50s to 1m57s.