### PR TITLE
Enhancement: Update for new Actify

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "behavior-tree"
-version = "0.1.39"
+version = "0.1.40"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.2", features = ["v1", "std", "rng"] }
 url = "2.2"
-actify = { git = "https://github.com/AvalorAI/actify", tag = "v0.6.0" }
+actify = { git = "https://github.com/AvalorAI/actify", tag = "v0.6.1" }
 
 [features]
 default = []


### PR DESCRIPTION
This update BT to use the new Actify version.
Depends on https://github.com/AvalorAI/actify/pull/30